### PR TITLE
Write eval results to tensorboard

### DIFF
--- a/train.py
+++ b/train.py
@@ -146,6 +146,11 @@ def main():
             recall, precision = eval_widerface.evaluate(dataloader_val,retinaface)
             print('Recall:',recall)
             print('Precision:',precision)
+	    writer.add_scalars('eval:',
+            {'recall': recall,
+            'precision': precision
+            },  
+            epoch)
 
         # Save model
         if (epoch + 1) % args.save_step == 0:


### PR DESCRIPTION
The console is the only other place the evaluation is shown and this only stays around as long as your buffer isn't full.
I think it's important for this to be in the tensorboard.

> -------- RetinaFace Pytorch --------
> Evaluating epoch 147
> 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 404/404 [01:43<00:00,  3.91it/s]
> Recall: 0.7351636132230178
> Precision: 0.9029628486077838

I've noticed my recall and precision is lower than expected but wasn't able to follow it back because it was lost in the buffer.